### PR TITLE
Format PHP data

### DIFF
--- a/lib/data_formatter/hash_collection.rb
+++ b/lib/data_formatter/hash_collection.rb
@@ -1,11 +1,21 @@
 module DataFormatter
   class HashCollection < Collection
     def open
-      @open ||= Tag.new(css_class: "curly-bracket", content: "{")
+      @open ||= case lang
+                when "php"
+                  Tag.new(css_class: "bracket", content: "[")
+                else
+                  Tag.new(css_class: "curly-bracket", content: "{")
+                end
     end
 
     def close
-      @close ||= Tag.new(css_class: "curly-bracket", content: "}")
+      @close ||= case lang
+                 when "php"
+                   Tag.new(css_class: "bracket", content: "]")
+                 else
+                   Tag.new(css_class: "curly-bracket", content: "}")
+                 end
     end
 
     def prepare(data)

--- a/lib/data_formatter/value.rb
+++ b/lib/data_formatter/value.rb
@@ -61,7 +61,13 @@ module DataFormatter
     end
 
     def format_nil
-      mark_up(data: (lang == "js" ? "null" : "nil"), kind: "nil")
+      case lang
+      when "ruby"
+        mark_up(data: "nil", kind: "nil")
+      else
+        # Default to JavaScript (PHP also uses null)
+        mark_up(data: "null", kind: "nil")
+      end
     end
 
     def format_hash

--- a/lib/data_formatter/value_pair.rb
+++ b/lib/data_formatter/value_pair.rb
@@ -2,10 +2,11 @@ module DataFormatter
   class ValuePair
     attr_reader :key, :value, :lang, :separator
 
-    SEPARATORS = {
+    # Defaults to JavaScript (JSON)
+    SEPARATORS = Hash.new(":").update({
       "ruby" => "=&gt;",
-      "js" => ":"
-    }
+      "php" => "=&gt;"
+    }).freeze
 
     def initialize(args)
       @key = args.fetch(:key)

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -85,4 +85,24 @@ describe "version" do
   it "Formats a literal" do
     _(DataFormatter.format("[LITERAL]Hello")).must_equal("<span class=\"literal\">Hello</span>")
   end
+
+  describe "JavaScript-style" do
+    it "formats a string => string hash" do
+      _(DataFormatter.format({"a" => "b"}, "js")).must_equal("<span class=\"curly-bracket\">{</span><span class=\"key string\">&quot;a&quot;</span><span class=\"hashrocket\">&nbsp;:&nbsp;</span><span class=\"string\">&quot;b&quot;</span><span class=\"curly-bracket\">}</span>")
+    end
+
+    it "formats a string => nil hash" do
+      _(DataFormatter.format({"a" => nil}, "js")).must_equal("<span class=\"curly-bracket\">{</span><span class=\"key string\">&quot;a&quot;</span><span class=\"hashrocket\">&nbsp;:&nbsp;</span><span class=\"nil\">null</span><span class=\"curly-bracket\">}</span>")
+    end
+  end
+
+  describe "PHP-style" do
+    it "formats a string => string hash" do
+      _(DataFormatter.format({"a" => "b"}, "php")).must_equal("<span class=\"bracket\">[</span><span class=\"key string\">&quot;a&quot;</span><span class=\"hashrocket\">&nbsp;=&gt;&nbsp;</span><span class=\"string\">&quot;b&quot;</span><span class=\"bracket\">]</span>")
+    end
+
+    it "formats a string => nil hash" do
+      _(DataFormatter.format({"a" => nil}, "php")).must_equal("<span class=\"bracket\">[</span><span class=\"key string\">&quot;a&quot;</span><span class=\"hashrocket\">&nbsp;=&gt;&nbsp;</span><span class=\"nil\">null</span><span class=\"bracket\">]</span>")
+    end
+  end
 end


### PR DESCRIPTION
- Customizes Hash format for PHP: `["key" => "value"]`
- Displays nil as `null` for PHP
- Defaults to JavaScript/JSON when not Ruby or PHP